### PR TITLE
最初に指定された回のディレクトリを作っておくようにした

### DIFF
--- a/bin/create.bash
+++ b/bin/create.bash
@@ -47,6 +47,7 @@ function main() {
 
   local root=$(dirname $0)/../
   local template=$root/template src=$root/src/$1
+  mkdir -p $src
   cp -r $template/base $src
   if [ $use_latexmk -eq 1 ]; then
     cp $template/latexmkrc $src/.latexmkrc


### PR DESCRIPTION
ディレクトリを作らないせいで、コピー先のディレクトリがなくなってテンプレートディレクトリをコピーできていない現象を確認した。
そこでコピーするためのディレクトリを最初に作っておくようにした。